### PR TITLE
Fix: Resolve undefined getters, remove unused imports, and apply styl…

### DIFF
--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -1,12 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:vector_map_tiles/vector_map_tiles.dart';
+import 'package:camping_osm_navi/models/routing_graph.dart';
+import 'package:camping_osm_navi/models/searchable_feature.dart';
 
 import '../models/location_info.dart';
 
 class LocationProvider with ChangeNotifier {
   LocationInfo? _selectedLocation;
   LocationInfo? get selectedLocation => _selectedLocation;
+
+  List<LocationInfo> _availableLocations = [];
+  List<LocationInfo> get availableLocations => _availableLocations;
+
+  bool _isLoadingLocationData = true;
+  bool get isLoadingLocationData => _isLoadingLocationData;
+
+  MapTheme? _mapTheme;
+  MapTheme? get mapTheme => _mapTheme;
+
+  RoutingGraph? _currentRoutingGraph;
+  RoutingGraph? get currentRoutingGraph => _currentRoutingGraph;
+
+  List<SearchableFeature> _currentSearchableFeatures = [];
+  List<SearchableFeature> get currentSearchableFeatures => _currentSearchableFeatures;
 
   Position? _currentPosition;
   Position? get currentPosition => _currentPosition;

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,6 +1,5 @@
 // lib/screens/map_screen.dart
 import 'dart:async';
-import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -79,7 +78,7 @@ class MapScreenState extends State<MapScreen> with MapScreenUIMixin {
   static const double _maneuverReachedThreshold = 15.0;
   static const double _significantGpsChangeThreshold = 2.0;
 
-  final Distance distanceCalculatorInstance = const Distance();
+  const Distance distanceCalculatorInstance = Distance();
 
   bool isRouteActiveForCardSwitch = false;
   final GlobalKey fullSearchCardKey = GlobalKey();


### PR DESCRIPTION
…e suggestion

- I added missing fields (availableLocations, isLoadingLocationData, mapTheme, currentRoutingGraph, currentSearchableFeatures) and their necessary imports to LocationProvider to resolve undefined getter errors in MapScreen.
- I removed unused import 'dart:math' from map_screen.dart.
- I removed unused import 'package:latlong2/latlong.dart' from location_provider.dart.
- I changed 'final' to 'const' for 'distanceCalculatorInstance' in map_screen.dart as per lint suggestion.