### PR TITLE
Fix: Ensure keyboard remains visible after selecting start/target

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_map/flutter_map.dart'; // Ensure this import is present 
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:vector_map_tiles/vector_map_tiles.dart' as vector_map_tiles;
+import 'package:latlong2/latlong.dart';
 
 import 'package:camping_osm_navi/models/location_info.dart';
 import 'package:camping_osm_navi/providers/location_provider.dart';
@@ -843,6 +844,7 @@ class MapScreenState extends State<MapScreen>
                   controller.startSearchController.text = feature.name;
                   controller.setStartLatLng(feature.center);
                   controller.updateStartMarker();
+                  controller.startFocusNode.requestFocus();
                   routeHandler.calculateRouteIfPossible();
                 },
               ),
@@ -854,6 +856,7 @@ class MapScreenState extends State<MapScreen>
                   controller.endSearchController.text = feature.name;
                   controller.setEndLatLng(feature.center);
                   controller.updateEndMarker();
+                  controller.endFocusNode.requestFocus();
                   routeHandler.calculateRouteIfPossible();
                 },
               ),

--- a/lib/screens/map_screen/map_screen_search_handler.dart
+++ b/lib/screens/map_screen/map_screen_search_handler.dart
@@ -259,12 +259,14 @@ class MapScreenSearchHandler {
       controller.startSearchController.text = feature.name;
       controller.setStartLatLng(point);
       controller.updateStartMarker();
+      controller.startFocusNode.requestFocus();
       // ✅ FIX 9: Kein automatischer unfocus bei Feature-Auswahl
       // controller.startFocusNode.unfocus(); // ENTFERNT
     } else if (controller.activeSearchField == ActiveSearchField.end) {
       controller.endSearchController.text = feature.name;
       controller.setEndLatLng(point);
       controller.updateEndMarker();
+      controller.endFocusNode.requestFocus();
       // ✅ FIX 10: Kein automatischer unfocus bei Feature-Auswahl
       // controller.endFocusNode.unfocus(); // ENTFERNT
     }


### PR DESCRIPTION
This commit addresses an issue where the keyboard would not consistently appear or remain visible after you selected a start or target point from:
1. Search results list
2. POI actions on map markers
3. Horizontal POI strip

The fix involves adding explicit `focusNode.requestFocus()` calls after the respective TextEditingController's text is updated in these selection handlers. This ensures that the relevant input field regains focus, prompting the keyboard to show or stay visible for further input from you.

Affected files:
- lib/screens/map_screen.dart
- lib/screens/map_screen/map_screen_search_handler.dart