### PR TITLE
Fix: Prevent LateInitializationError for MapController

### DIFF
--- a/lib/screens/map_screen/map_screen_gps_handler.dart
+++ b/lib/screens/map_screen/map_screen_gps_handler.dart
@@ -135,14 +135,28 @@ class MapScreenGpsHandler {
       _onGpsPositionChanged(newGpsLatLng);
 
       if (controller.followGps) {
-        controller.mapController
-            .move(newGpsLatLng, MapScreenController.followGpsZoomLevel);
+        if (!controller.isMapReady) {
+          if (kDebugMode) {
+            print(
+                "[MapScreenGpsHandler] Map not ready, cannot follow GPS in _handleNewGpsPosition");
+          }
+        } else {
+          controller.mapController
+              .move(newGpsLatLng, MapScreenController.followGpsZoomLevel);
+        }
       }
     }
   }
 
   // ✅ NEUE METHODE: Auto-Zentrierung mit Animation
   void _autoMoveToGpsPosition(LatLng gpsPosition) {
+    if (!controller.isMapReady) {
+      if (kDebugMode) {
+        print(
+            "[MapScreenGpsHandler] Map not ready, deferring _autoMoveToGpsPosition for position: ${gpsPosition.latitude}, ${gpsPosition.longitude}");
+      }
+      return;
+    }
     // Aktiviere Follow-GPS automatisch
     controller.setFollowGps(true);
 
@@ -196,6 +210,12 @@ class MapScreenGpsHandler {
 
   void centerOnGps() {
     if (controller.currentGpsPosition != null) {
+      if (!controller.isMapReady) {
+        if (kDebugMode) {
+          print("[MapScreenGpsHandler] Map not ready, cannot centerOnGps");
+        }
+        return;
+      }
       controller.setFollowGps(true);
       controller.mapController.move(controller.currentGpsPosition!,
           MapScreenController.followGpsZoomLevel);


### PR DESCRIPTION
The MapController.move() method was being called from MapScreenGpsHandler during the didChangeDependencies lifecycle, potentially before the FlutterMap widget was fully initialized and ready. This led to a LateInitializationError for an internal field in MapControllerImpl.

This commit introduces checks for the `MapScreenController.isMapReady` flag in the following methods within `MapScreenGpsHandler`:
- _autoMoveToGpsPosition
- centerOnGps
- _handleNewGpsPosition (for the followGps case)

These checks ensure that `MapController.move()` is only called after the FlutterMap's onMapReady callback has signaled that the map is ready. The initial map positioning is still handled correctly via the logic in `MapScreenState.onMapReady`.