### PR TITLE
Fix issues in map_screen_controller_test.dart

### DIFF
--- a/lib/screens/map_screen/map_screen_controller.dart
+++ b/lib/screens/map_screen/map_screen_controller.dart
@@ -153,19 +153,17 @@ class MapScreenController with ChangeNotifier {
 
   void toggleStartLock() {
     _isStartLocked = !_isStartLocked;
-    _attemptRouteCalculationOrClearRoute();
+    attemptRouteCalculationOrClearRoute();
     notifyListeners();
   }
 
   void toggleDestinationLock() {
     _isDestinationLocked = !_isDestinationLocked;
-    _attemptRouteCalculationOrClearRoute();
+    attemptRouteCalculationOrClearRoute();
     notifyListeners();
   }
 
-  // ignore: invalid_visibility_annotation
-  @visibleForTesting // Hinzugefügt
-  Future<void> _attemptRouteCalculationOrClearRoute() async {
+  Future<void> attemptRouteCalculationOrClearRoute() async {
     if (isStartLocked &&
         isDestinationLocked &&
         _selectedStart != null &&
@@ -267,7 +265,7 @@ class MapScreenController with ChangeNotifier {
   }
 
   void _tryCalculateRoute() {
-    _attemptRouteCalculationOrClearRoute();
+    attemptRouteCalculationOrClearRoute();
   }
 
   void setRerouting(bool rerouting) {
@@ -393,7 +391,7 @@ class MapScreenController with ChangeNotifier {
     _isDestinationLocked = false;
     if (startFocusNode.hasFocus) startFocusNode.unfocus();
     if (endFocusNode.hasFocus) endFocusNode.unfocus();
-    _attemptRouteCalculationOrClearRoute();
+    attemptRouteCalculationOrClearRoute();
     notifyListeners();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -420,26 +420,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
@@ -753,10 +753,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:
@@ -801,10 +801,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vector_tile:
     dependency: transitive
     description:
@@ -825,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:

--- a/test/map_screen_controller_test.dart
+++ b/test/map_screen_controller_test.dart
@@ -3,6 +3,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter/widgets.dart';
 
 // Importiere das Original, um @visibleForTesting nutzen zu können
 import 'package:camping_osm_navi/screens/map_screen/map_screen_controller.dart';
@@ -12,6 +13,7 @@ import 'package:camping_osm_navi/models/maneuver.dart';
 import 'package:camping_osm_navi/models/searchable_feature.dart';
 import 'package:camping_osm_navi/models/graph_node.dart'; // Corrected import for GraphNode
 import 'package:camping_osm_navi/models/graph_edge.dart'; // Added import for GraphEdge
+import 'package:camping_osm_navi/models/routing_graph.dart';
 // import 'package:camping_osm_navi/services/routing_service.dart'; // Wird im Test nicht direkt verwendet
 
 // Generiere Mocks. Stellen Sie sicher, dass 'flutter pub run build_runner build' ausgeführt wurde.
@@ -19,7 +21,9 @@ import 'package:camping_osm_navi/models/graph_edge.dart'; // Added import for Gr
 import 'map_screen_controller_test.mocks.dart';
 
 class MockGraphNode extends Mock implements GraphNode {
+  @override
   final String id;
+  @override
   final LatLng position;
 
   MockGraphNode({required this.id, required this.position});
@@ -49,6 +53,7 @@ class MockGraphNode extends Mock implements GraphNode {
 }
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   late MapScreenController mapScreenController;
   late MockLocationProvider mockLocationProvider;
   late MockRoutingGraph mockRoutingGraph;
@@ -135,7 +140,7 @@ void main() {
     setUp(() {
       mapScreenController.setStartLocation(startFeature);
       mapScreenController.setDestination(destinationFeature);
-      clearInteractions(mapScreenController);
+      // clearInteractions(mapScreenController); // Removed incorrect usage
     });
 
     test('clears route if start is not locked', () async {
@@ -202,6 +207,6 @@ extension TestHelpers on MapScreenController {
   Future<void> sendUpdatedRouteCalculationOrClearRoute() async {
     // Ruft die @visibleForTesting Methode im MapScreenController auf.
     // Dies ist der vorgesehene Weg, um die private Logik testbar zu machen.
-    await _attemptRouteCalculationOrClearRoute();
+    await this.attemptRouteCalculationOrClearRoute();
   }
 }


### PR DESCRIPTION
This commit addresses several errors and lint warnings in the `test/map_screen_controller_test.dart` file:

- Resolved "Undefined name 'RoutingGraph'" by ensuring the correct import and running build_runner.
- Ensured `const` correctness, relying on `build_runner` to resolve type literal issues for `@GenerateMocks`.
- Fixed "Undefined method '_attemptRouteCalculationOrClearRoute'" by renaming the method to `attemptRouteCalculationOrClearRoute` (making it public) and updating its call sites in the tests. This also involved removing the `@visibleForTesting` annotation as it's no longer private.
- Added `@override` annotations to `id` and `position` members in `MockGraphNode` to fix `annotate_overrides` warnings.
- Ensured `WidgetsFlutterBinding.ensureInitialized()` is called in the test setup to prevent issues with plugin initialization (e.g., for flutter_tts).
- Removed an erroneous `clearInteractions` call that was causing a `NoSuchMethodError`.

All tests in `test/map_screen_controller_test.dart` now pass.