### PR TITLE
Fix various Dart analyzer errors and warnings

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -276,8 +276,7 @@ class MapScreenState extends State<MapScreen>
       totalTime: controller.routeTimeMinutes,
       isNavigating: controller.followGps && controller.currentGpsPosition != null,
       onEditPressed: () {
-        controller.showRouteInfoAndFadeFields = false; // Switch back to full search
-        controller.notifyListeners();
+        controller.setRouteInfoAndFadeFields(false); // Switch back to full search
       },
       onClosePressed: () {
         routeHandler.clearRoute(showConfirmation: true); // End navigation
@@ -396,7 +395,7 @@ class MapScreenState extends State<MapScreen>
   Widget _buildCalculatingOverlay() {
     return Positioned.fill(
       child: Container(
-        color: Colors.black.withOpacity(0.3), // Standardized opacity
+        color: Colors.black.withAlpha((0.3 * 255).round()), // Standardized opacity
         child: const Center(
           child: CircularProgressIndicator(color: Colors.white),
         ),
@@ -407,7 +406,7 @@ class MapScreenState extends State<MapScreen>
   Widget _buildReroutingOverlay() {
     return Positioned.fill(
       child: Container(
-        color: Colors.black.withOpacity(0.2), // Standardized opacity
+        color: Colors.black.withAlpha((0.2 * 255).round()), // Standardized opacity
         child: const Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -426,7 +425,7 @@ class MapScreenState extends State<MapScreen>
   Widget _buildLoadingOverlay(LocationInfo? selectedLocation) {
     return Positioned.fill(
       child: Container(
-        color: Colors.black.withOpacity(0.7), // Standardized opacity
+        color: Colors.black.withAlpha((0.7 * 255).round()), // Standardized opacity
         child: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -597,10 +596,8 @@ class MapScreenState extends State<MapScreen>
 
     String shareText = "Route to: $destination";
     if (distance != null && time != null) {
-      shareText += "
-Distance: ${controller.formatDistance(distance)}"; // Uses new helper
-      shareText += "
-Walking time: about $time minutes";
+      shareText += "\nDistance: ${controller.formatDistance(distance)}"; // Uses new helper
+      shareText += "\nWalking time: about $time minutes";
     }
 
     // Placeholder for actual sharing logic (e.g., using share_plus)

--- a/lib/screens/map_screen/map_screen_controller.dart
+++ b/lib/screens/map_screen/map_screen_controller.dart
@@ -61,6 +61,10 @@ class MapScreenController with ChangeNotifier {
   bool _compactSearchMode = false;
   bool showRouteInfoAndFadeFields = false;
 
+  // TTS state for route updates
+  double? lastSpokenDistance;
+  int? lastSpokenTime;
+
   // Getters
   SearchableFeature? get selectedStart => _selectedStart;
   SearchableFeature? get selectedDestination => _selectedDestination;
@@ -325,12 +329,11 @@ class MapScreenController with ChangeNotifier {
     // Automatic TTS for significant changes
     if (distance != null && timeMinutes != null) {
       // TTS only for large changes (> 1 minute or > 100m)
-      static double? lastSpokenDistance;
-      static int? lastSpokenTime;
+      // lastSpokenDistance and lastSpokenTime are now instance variables
 
-      if (lastSpokenDistance == null || lastSpokenTime == null ||
-          (distance - lastSpokenDistance!).abs() > 100 ||
-          (timeMinutes - lastSpokenTime!).abs() >= 1) {
+      if (this.lastSpokenDistance == null || this.lastSpokenTime == null ||
+          (distance - this.lastSpokenDistance!).abs() > 100 ||
+          (timeMinutes - this.lastSpokenTime!).abs() >= 1) {
 
         if (timeMinutes <= 1) {
           ttsService.speakImmediate("Destination almost reached.");
@@ -338,8 +341,8 @@ class MapScreenController with ChangeNotifier {
           ttsService.speakImmediate("About $timeMinutes minutes to destination.");
         }
 
-        lastSpokenDistance = distance;
-        lastSpokenTime = timeMinutes;
+        this.lastSpokenDistance = distance;
+        this.lastSpokenTime = timeMinutes;
       }
     }
 
@@ -470,6 +473,14 @@ class MapScreenController with ChangeNotifier {
   void toggleSearchInterfaceMode() {
     showRouteInfoAndFadeFields = !showRouteInfoAndFadeFields;
     notifyListeners();
+  }
+
+  // Method to control showRouteInfoAndFadeFields and notify listeners
+  void setRouteInfoAndFadeFields(bool value) {
+    if (showRouteInfoAndFadeFields != value) {
+      showRouteInfoAndFadeFields = value;
+      notifyListeners();
+    }
   }
 
   // NEW: Helper method for distance formatting

--- a/lib/widgets/simple_search_container.dart
+++ b/lib/widgets/simple_search_container.dart
@@ -118,8 +118,7 @@ class _SimpleSearchContainerState extends State<SimpleSearchContainer>
 
   void _expandSearchFields() {
     // Activate edit mode
-    widget.controller.showRouteInfoAndFadeFields = false;
-    widget.controller.notifyListeners();
+    widget.controller.setRouteInfoAndFadeFields(false);
   }
 
   @override


### PR DESCRIPTION
This commit addresses a range of issues reported by the Dart analyzer:

- I corrected syntax errors in `lib/screens/map_screen.dart` related to string formatting and variable usage in the `_shareRoute` method. This included fixing unterminated string literals and ensuring proper statement termination.
- I resolved errors in `lib/screens/map_screen/map_screen_controller.dart` by:
    - Removing `static` modifiers from `lastSpokenDistance` and `lastSpokenTime` and making them instance variables to correctly manage state for TTS announcements.
    - This change also clarified the logic for null checks and assertions related to these variables.
- I fixed `invalid_use_of_protected_member` errors for `notifyListeners` by:
    - Creating a new method `setRouteInfoAndFadeFields` in `MapScreenController` that encapsulates the state change and the call to `notifyListeners`.
    - I updated `lib/screens/map_screen.dart` and `lib/widgets/simple_search_container.dart` to use this new method, promoting better state management.
- I replaced deprecated `withOpacity` calls with `withAlpha` in `lib/screens/map_screen.dart` for color definitions in overlay widgets.